### PR TITLE
Changes to get make.rb to work under Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You need to install:
 
 Edit the file make.rb. At the top of the file, you need to specify paths to the Acme assembler, the Vice C64 emulator, and the program "1541" which is also included in the Vice distribution.
 
-To build a game, you run something like "./make.sh game.z5" or "ruby make.rb game.z5" Add -p to make the game start in Vice when it has been built. Run make.rb without arguments to view all options.
+To build a game, you run something like "ruby make.rb game.z5" Add -p to make the game start in Vice when it has been built. Run make.rb without arguments to view all options.
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To build a game, you run something like "./make.sh game.z5" or "ruby make.rb gam
 
 Acme can be downloaded from [Github](https://github.com/meonwax/acme) and compiled.
 
+Exomizer can be downloaded from [Bitbucket](https://bitbucket.org/magli143/exomizer/wiki/Home) and compiled.
+
 Vice is available on Debian/Ubuntu with:
 > sudo apt-get install vice
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ You need to install:
 
 Edit the file make.rb. At the top of the file, you need to specify paths to the Acme assembler, the Vice C64 emulator, and the program "1541" which is also included in the Vice distribution.
 
-To build a game, you run something like "./make.rb game.z5" Add -p to make the game start in Vice when it has been built. Run make.rb without arguments to view all options.
+To build a game, you run something like "./make.sh game.z5" or "ruby make.rb game.z5" Add -p to make the game start in Vice when it has been built. Run make.rb without arguments to view all options.
 
 ### Linux
 
-Acme can be downloaded from [SourceForge](https://sourceforge.net/projects/acme-crossass/)
+Acme can be downloaded from [Github](https://github.com/meonwax/acme) and compiled.
 
 Vice is available on Debian/Ubuntu with:
 > sudo apt-get install vice

--- a/make.rb
+++ b/make.rb
@@ -25,10 +25,12 @@ if $is_windows then
     $X64 = "C:\\ProgramsWoInstall\\WinVICE-3.1-x64\\x64.exe -autostart-warp" # -autostart-delay-random"
     $C1541 = "C:\\ProgramsWoInstall\\WinVICE-3.1-x64\\c1541.exe"
     $EXOMIZER = "C:\\ProgramsWoInstall\\Exomizer-3.0.0\\win32\\exomizer.exe"
+    $ACME = "acme.exe"
 else
     $X64 = "/usr/bin/x64 -autostart-delay-random"
     $C1541 = "/usr/bin/c1541"
     $EXOMIZER = "exomizer/src/exomizer"
+    $ACME = "acme"
 end
 
 
@@ -296,7 +298,7 @@ def build_interpreter(use_compression)
     else
         $COMPRESSIONFLAGS = ""
     end
-    cmd = "acme/src/acme #{$COMPRESSIONFLAGS} -D#{$ztype}=1 #{$DEBUGFLAGS} #{$VMFLAGS} --cpu 6510 --format cbm -l acme_labels.txt --outfile ozmoo ozmoo.asm"
+    cmd = "#{$ACME} #{$COMPRESSIONFLAGS} -D#{$ztype}=1 #{$DEBUGFLAGS} #{$VMFLAGS} --cpu 6510 --format cbm -l acme_labels.txt --outfile ozmoo ozmoo.asm"
 	puts cmd
     ret = system(cmd)
     exit 0 if !ret
@@ -454,7 +456,7 @@ if $ztype.empty?
 	end
 end
 if extension.empty? then
-    puts "ERROR: cannot figure ut zmachine version. Please specify"
+    puts "ERROR: cannot figure out zmachine version. Please specify"
     exit 0
 end
 
@@ -560,5 +562,4 @@ else
 end
 
 exit 0
-
 

--- a/make.sh
+++ b/make.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-ruby make.rb $@
-rm temp1.d64 2&>/dev/null
-#mv *.d64 ./disks/

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /home/semjaza/Desktop/infocom/ozmoo
+ruby make.rb $@
+rm temp1.d64 2&>/dev/null
+#mv *.d64 ./disks/

--- a/make.sh
+++ b/make.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-cd /home/semjaza/Desktop/infocom/ozmoo
 ruby make.rb $@
 rm temp1.d64 2&>/dev/null
 #mv *.d64 ./disks/


### PR DESCRIPTION
Changed "FileUtils" in make.rb to "fileutils" as Linux is case sensitive and required the include to be all lower case.

Modified README.md to point towards the acme compiler on github, which compiles and works under Linux (Ubuntu 16.04 tested).

Modified README.md to state that the program should be called with either "ruby make.rb game.z5" or the make.sh script which simply does the aforementioned.

Changed make.rb so that it accepts z[1-8] as an argument. Also modified it so that when .dat files are passed with a -z[1-8] the passed parameter kicks in and the d64 file gets made, instead of failing.

I hacked and slashed at some stuff here. However, it seems to work under Linux mostly now.

Removed the "-cartcrt final_cartridge.crt" from the calls to x64 while debugging. Left it off and seems to have caused to ill effects. Since leaving it off simplifies things, I went with leaving it out.

Added link to exomizer to README.md 
