### PR TITLE
Added conditionally-compiled cursor blinking for z3

### DIFF
--- a/asm/ozmoo.asm
+++ b/asm/ozmoo.asm
@@ -214,6 +214,10 @@ game_id		!byte 0,0,0,0
 	jsr splash_screen
 }
 
+!ifdef CURSORBLINK {
+	jsr init_cursor_blinker
+}
+
 !ifdef VMEM {
 	jsr reu_start
 }

--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -568,27 +568,17 @@ cursor_blinker
 	beq .switch_on
 .switch_off
 	dec $cf
-	jsr cursor_blink_off
-	jmp .reset_countdown
+	lda #$20	; blank space
+	jmp .update
 .switch_on
 	inc $cf
-	jsr cursor_blink_on
-.reset_countdown
-	lda #$20	; reset to $20 jiffies
+	lda #CURSORCHAR ; intended cursor character
+.update
+	sta cursor_character	; update the cursor character
+	jsr update_cursor	; redraw the cursor character on screen
+	lda #$20		; reset counter to $20 jiffies
 	sta $cd
 .ack
 	asl $d019	; ACK interrupt
 	jmp $ea31	; return from interrupt
-
-cursor_blink_on
-	lda #CURSORCHAR
-	sta cursor_character
-	jsr update_cursor
-	rts
-
-cursor_blink_off
-	lda #$20	; blank space
-	sta cursor_character
-	jsr update_cursor
-	rts
 }

--- a/documentation/colours.txt
+++ b/documentation/colours.txt
@@ -35,6 +35,8 @@ The color (and shape) of the cursor can also be customized:
 -cs:(Cursor shape)
     Cursor shape: either of b,u or l; where b=block (default) shape, u=underscore shape and l=line shape.
 
+-cb
+    Cursor blinks.  This is only possible with version 3 story files (z3).
 
 Z-code has a palette of 8 colours, numbered 2-9:
 

--- a/make.rb
+++ b/make.rb
@@ -615,6 +615,9 @@ def build_interpreter()
 		}
 		colourflags += " -DCURSORCHAR=#{cursor_shapes[$cursor_shape]}"
 	end
+	if $cursor_blink
+		colourflags += " -DCURSORBLINK=1"
+	end
 	fontflag = $font_filename ? ' -DCUSTOM_FONT=1' : ''
     compressionflags = ''
 
@@ -1107,7 +1110,7 @@ def print_usage_and_exit
 	puts "         [-sp:[n]] [-s] [-x] [-r] [-f <fontfile>] [-cm:[xx]]"
 	puts "         [-rc:[n]=[c],[n]=[c]...] [-dc:[n]:[n]] [-bc:[n]] [-sc:[n]]"
 	puts "         [-dmdc:[n]:[n]] [-dmbc:[n]] [-dmsc:[n]] [-ss[1-4]:\"text\"]"
-	puts "         [-sw:[nnn]] [-cc:[n]] [-dmcc:[n]] [-cs:[b|u|l]] "
+	puts "         [-sw:[nnn]] [-cc:[n]] [-dmcc:[n]] [-cs:[b|u|l]] [-cb]"
 	puts "         <storyfile>"
 	puts "  -S1|-S2|-D2|-D3|-81|-P: specify build mode. Defaults to S1. See docs for details."
 	puts "  -p: preload a a maximum of n virtual memory blocks to make game faster at start"
@@ -1126,6 +1129,7 @@ def print_usage_and_exit
 	puts "  -sw: Set the splash screen wait time (0-999 s). Default is 10 if text has been added, 3 if not."
 	puts "  -cc/dmcc: Use the specified cursor colour.  Defaults to foreground colour."
 	puts "  -cs: Use the specified cursor shape.  ([b]lock (default), [u]nderscore or [l]ine)"
+  puts "  -cb: Cursor blinks.  Only valid for Z3 games."
 	puts "  storyfile: path optional (e.g. infocom/zork1.z3)"
 	exit 1
 end
@@ -1157,8 +1161,6 @@ $stack_pages = 4 # Should normally be 2-6. Use 4 unless you have a good reason n
 $border_colour = 0
 $char_map = nil
 $splash_wait = nil
-$cursor_colour = nil
-$cursor_shape = nil
 
 begin
 	while i < ARGV.length
@@ -1224,6 +1226,8 @@ begin
 			$cursor_colour_dm = $1.to_i
 		elsif ARGV[i] =~ /^-cs:([b|u|l])$/ then
 			$cursor_shape = $1
+		elsif ARGV[i] =~ /^-cb$/ then
+			$cursor_blink = true
 		elsif ARGV[i] =~ /^-/i then
 			puts "Unknown option: " + ARGV[i]
 			raise "error"
@@ -1367,6 +1371,11 @@ if $statusline_colour and $zcode_version > 3
 	puts "Option -sc can only be used with z3 story files."
 	exit 1
 end	
+
+if $cursor_blink and $zcode_version > 3
+	puts "Option -cb can only be used with z3 story files."
+	exit 1
+end
 
 # check header.high_mem_start (size of dynmem + statmem)
 high_mem_start = $story_file_data[4 .. 5].unpack("n")[0]


### PR DESCRIPTION
Reuses the kernal's `$CD` and `$CF` zero page locations for jiffy countdown and blink phase respectively. 

This _seems_ to work fine in z3, but is definitely broken in z5 Borderzone where it mangles the status line.  It does not however appear to interfere with the z-machine interrupt timer events, as the first Borderzone event still fired fine.

If in the future other raster interrupts are desired, some kind of mechanism for chaining raster interrupts will be desired.

Resolves #9 