### PR TITLE
Add vmem stress test and fix some vmem bugs

### DIFF
--- a/asm/ozmoo.asm
+++ b/asm/ozmoo.asm
@@ -623,6 +623,9 @@ deletable_init
 	lda #vmap_max_size
 ++	
 }
+!ifdef VMEM_STRESS {
+        lda #2 ; one block for PC, one block for data
+}
 	sta vmap_max_entries
 
 	jsr prepare_static_high_memory

--- a/asm/utilities.asm
+++ b/asm/utilities.asm
@@ -92,6 +92,7 @@ ERROR_OUT_OF_MEMORY = 12
 ERROR_WRITE_ABOVE_DYNMEM = 13
 ERROR_READ_ABOVE_STATMEM = 14
 ERROR_TOO_MANY_TERMINATORS = 15
+ERROR_NO_VMEM_INDEX = 16
 
 !ifdef DEBUG {
 .error_unsupported_stream !pet "unsupported stream#",0
@@ -109,6 +110,7 @@ ERROR_TOO_MANY_TERMINATORS = 15
 .error_write_above_dynmem !pet "tried to write to non-dynamic memory", 0
 .error_read_above_statmem !pet "tried to read from himem", 0
 .error_too_many_terminators !pet "too many terminators", 0
+.error_no_vmem_index !pet "no vmem index found", 0
 
 .error_message_high_arr
     !byte >.error_unsupported_stream
@@ -126,6 +128,7 @@ ERROR_TOO_MANY_TERMINATORS = 15
     !byte >.error_write_above_dynmem
     !byte >.error_read_above_statmem
     !byte >.error_too_many_terminators
+    !byte >.error_no_vmem_index
 
 .error_message_low_arr
     !byte <.error_unsupported_stream
@@ -143,6 +146,7 @@ ERROR_TOO_MANY_TERMINATORS = 15
     !byte <.error_write_above_dynmem
     !byte <.error_read_above_statmem
     !byte <.error_too_many_terminators
+    !byte <.error_no_vmem_index
 }
 
 fatalerror

--- a/asm/vmem.asm
+++ b/asm/vmem.asm
@@ -508,21 +508,32 @@ read_byte_at_z_address
 	jmp print_optimized_vm_map
 }	
 }
-	; Store age and index of entry at vmap_clock_index
-	lda vmap_z_h,x
-	stx vmem_oldest_index
+        ; Store very recent oldest_age so the first valid index in the following
+        ; loop will be picked as the first candidate.
+        lda #$ff
+!ifdef DEBUG {
+        sta vmem_oldest_index
+}
 	sta vmem_oldest_age
+        bne ++ ; Always branch
 	
 	; Check all other indexes to find something older
 -	lda vmap_z_h,x
 	cmp vmem_oldest_age
 	bcs +
+++
 	; Found older
-	; Skip if z_pc points here
+	; Skip if z_pc points here; it could be in either page of the block.
+!ifndef SMALLBLOCK {
+	!error "Only SMALLBLOCK supported"
+}
 	ldy vmap_z_l,x
 	cpy z_pc + 1
-	bne ++
-	tay
+	beq +++
+        iny
+        cpy z_pc + 1
+        bne ++
++++	tay
 	and #vmem_highbyte_mask
 	cmp z_pc
 	beq +
@@ -566,6 +577,15 @@ read_byte_at_z_address
 	ldy #0
 .not_max_index
 	sty vmap_clock_index
+
+!ifdef DEBUG {
+        lda vmem_oldest_index
+        cmp #$ff
+        bne +
+        lda #ERROR_NO_VMEM_INDEX
+        jsr fatalerror
++
+}
 
 	; We have now decided on a map position where we will store the requested block. Position is held in x.
 !ifdef DEBUG {

--- a/make.rb
+++ b/make.rb
@@ -32,10 +32,11 @@ $GENERALFLAGS = [
 
 # For a production build, none of these flags should be enabled.
 $DEBUGFLAGS = [
-#	'DEBUG', # This gives some debug capabilities, like informative error messages. It is automatically included if any other debug flags are used.
+	'DEBUG', # This gives some debug capabilities, like informative error messages. It is automatically included if any other debug flags are used.
 #	'VIEW_STACK_RECORDS',
 #	'PRINTSPEED'
-#	'BENCHMARK',
+	'BENCHMARK',
+	'VMEM_STRESS', # very slow but gives vmem a workout
 #	'TRACE_FLOPPY',
 #	'TRACE_VM',
 #	'PRINT_SWAPS',

--- a/make.rb
+++ b/make.rb
@@ -32,11 +32,11 @@ $GENERALFLAGS = [
 
 # For a production build, none of these flags should be enabled.
 $DEBUGFLAGS = [
-	'DEBUG', # This gives some debug capabilities, like informative error messages. It is automatically included if any other debug flags are used.
+#	'DEBUG', # This gives some debug capabilities, like informative error messages. It is automatically included if any other debug flags are used.
 #	'VIEW_STACK_RECORDS',
 #	'PRINTSPEED'
-	'BENCHMARK',
-	'VMEM_STRESS', # very slow but gives vmem a workout
+#	'BENCHMARK',
+#	'VMEM_STRESS', # very slow but gives vmem a workout
 #	'TRACE_FLOPPY',
 #	'TRACE_VM',
 #	'PRINT_SWAPS',


### PR DESCRIPTION
Hi,

I've been playing around with the virtual memory implementation as part of my Acorn port of ozmoo (https://stardot.org.uk/forums/viewtopic.php?f=2&t=19975&p=279511#p279067).

This pull request adds a new debug option VMEM_STRESS which forces only two blocks of virtual memory to be available to stress-test the virtual memory system. Since we only need one block for the PC and one block for data access, I think this should work, although of course it's incredibly slow. I found two bugs in the virtual memory implementation which stopped this working; these are fixed by one of the commits on this branch (and the commit message has further details). With this fix, the benchmark runs without crashing as far as I've had time to execute it.

I haven't seen these bugs trigger in a more realistic situation, but I don't think it's impossible they could come into play so I think it's worth fixing them.

Let me know if you have any questions!

Cheers.

Steve