### PR TITLE
Improve handling of reverse video in buffered text output

### DIFF
--- a/asm/constants.asm
+++ b/asm/constants.asm
@@ -111,6 +111,7 @@ cursor_column		  = $f9 ; 2 bytes
 zp_temp               = $fb ; 5 bytes
 
 print_buffer		  = $100 ; 41 bytes
+print_buffer2             = $129 ; 41 bytes
 
 memory_buffer         =	$02a7
 memory_buffer_length  = 89


### PR DESCRIPTION
Hi,

I noticed that the "styled text" test in etude.z5 doesn't show reverse video, even though Ozmoo supports it. I've investigated and the problem seems to be that the reverse/normal video control codes get processed immediately but the intervening text is buffered, so we've reverted to normal video by the time the buffered text is output.

These changes add a parallel print_buffer2 (I'm assuming there is enough room at the bottom of the stack for this) and track the s_reverse status for buffered text in there. This will slow down buffered text processing a little bit, of course; I don't know if you think this is a problem or not.

I've attached a composite screenshot showing the results with and without this change; without on the left, with on the right.

Let me know if you have any questions, of course!

Cheers.

Steve
![ozmoo-reverse-video](https://user-images.githubusercontent.com/7988240/88862030-2ec4d400-d1f7-11ea-846d-c3fde8ce1995.png)
