### PR TITLE
Screenkernal scrolling code optimizations

### DIFF
--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -792,6 +792,17 @@ s_scrolled_lines !byte 0
 	sta .scroll_load_colour_2 + 2
 	dec zp_screenrow
 	jsr .update_screenpos
+	lda zp_screenline
+	sta .scroll_load_screen + 4
+	sta .scroll_load_screen_2 + 4
+	sta .scroll_load_colour + 4
+	sta .scroll_load_colour_2 + 4
+	lda zp_screenline + 1
+	sta .scroll_load_screen + 5
+	sta .scroll_load_screen_2 + 5
+	lda zp_colourline + 1
+	sta .scroll_load_colour + 5
+	sta .scroll_load_colour_2 + 5
 	lda s_screen_height_minus_one
 	sec
 	sbc zp_screenrow
@@ -800,37 +811,42 @@ s_scrolled_lines !byte 0
 	ldy s_screen_width_minus_one
 .scroll_load_screen
 	lda $8000,y ; This address is modified above
-	sta (zp_screenline),y
+	sta $8000,y ; This address is modified above
 .scroll_load_colour
 	lda $8000,y ; This address is modified above
-	sta (zp_colourline),y
+	sta $8000,y ; This address is modified above
 	dey
 .scroll_load_screen_2
 	lda $8000,y ; This address is modified above
-	sta (zp_screenline),y
+	sta $8000,y ; This address is modified above
 .scroll_load_colour_2
 	lda $8000,y ; This address is modified above
-	sta (zp_colourline),y
+	sta $8000,y ; This address is modified above
 	dey
 	bpl .scroll_load_screen
 	dex
 	beq .done_scrolling
-	lda zp_screenline
-	clc
-	adc s_screen_width
-	sta zp_screenline
-	sta zp_colourline
-	bcc +
-	inc zp_screenline + 1
-	inc zp_colourline + 1
-+
+
+	; new row: store where we previously loaded...
 	lda .scroll_load_screen + 1
+	sta .scroll_load_screen + 4
+	sta .scroll_load_colour + 4
+	sta .scroll_load_screen_2 + 4
+	sta .scroll_load_colour_2 + 4
+	; ...and load from the next row.
 	clc
 	adc s_screen_width
 	sta .scroll_load_screen + 1
 	sta .scroll_load_colour + 1
 	sta .scroll_load_screen_2 + 1
 	sta .scroll_load_colour_2 + 1
+
+	lda .scroll_load_screen + 2
+	sta .scroll_load_screen + 5
+	sta .scroll_load_screen_2 + 5
+	lda .scroll_load_colour + 2
+	sta .scroll_load_colour + 5
+	sta .scroll_load_colour_2 + 5
 	bcc +
 	inc .scroll_load_screen + 2
 	inc .scroll_load_colour + 2

--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -781,12 +781,16 @@ s_scrolled_lines !byte 0
 	jsr .update_screenpos
 	lda zp_screenline
 	sta .scroll_load_screen + 1
+	sta .scroll_load_screen_2 + 1
 	lda zp_screenline + 1
 	sta .scroll_load_screen + 2
+	sta .scroll_load_screen_2 + 2
 	lda zp_colourline
 	sta .scroll_load_colour + 1
+	sta .scroll_load_colour_2 + 1
 	lda zp_colourline + 1
 	sta .scroll_load_colour + 2
+	sta .scroll_load_colour_2 + 2
 	dec zp_screenrow
 	jsr .update_screenpos
 	lda s_screen_height_minus_one
@@ -802,6 +806,13 @@ s_scrolled_lines !byte 0
 	lda $8000,y ; This address is modified above
 	sta (zp_colourline),y
 	dey
+.scroll_load_screen_2
+	lda $8000,y ; This address is modified above
+	sta (zp_screenline),y
+.scroll_load_colour_2
+	lda $8000,y ; This address is modified above
+	sta (zp_colourline),y
+	dey
 	bpl .scroll_load_screen
 	dex
 	beq .done_scrolling
@@ -811,7 +822,7 @@ s_scrolled_lines !byte 0
 	sta zp_screenline
 	bcc +
 	inc zp_screenline + 1
-+		
++
 	lda zp_colourline
 	clc
 	adc s_screen_width
@@ -823,16 +834,21 @@ s_scrolled_lines !byte 0
 	clc
 	adc s_screen_width
 	sta .scroll_load_screen + 1
+	sta .scroll_load_screen_2 + 1
 	bcc +
 	inc .scroll_load_screen + 2
-+		
+	inc .scroll_load_screen_2 + 2
++
 	lda .scroll_load_colour + 1
 	clc
 	adc s_screen_width
 	sta .scroll_load_colour + 1
+	sta .scroll_load_colour_2 + 1
 	bcc +
 	inc .scroll_load_colour + 2
-+	jmp -
+	inc .scroll_load_colour_2 + 2
++
+ 	jmp -
 
 .done_scrolling
 !ifdef TARGET_MEGA65 {

--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -782,12 +782,11 @@ s_scrolled_lines !byte 0
 	lda zp_screenline
 	sta .scroll_load_screen + 1
 	sta .scroll_load_screen_2 + 1
+	sta .scroll_load_colour + 1
+	sta .scroll_load_colour_2 + 1
 	lda zp_screenline + 1
 	sta .scroll_load_screen + 2
 	sta .scroll_load_screen_2 + 2
-	lda zp_colourline
-	sta .scroll_load_colour + 1
-	sta .scroll_load_colour_2 + 1
 	lda zp_colourline + 1
 	sta .scroll_load_colour + 2
 	sta .scroll_load_colour_2 + 2
@@ -820,32 +819,22 @@ s_scrolled_lines !byte 0
 	clc
 	adc s_screen_width
 	sta zp_screenline
-	bcc +
-	inc zp_screenline + 1
-+
-	lda zp_colourline
-	clc
-	adc s_screen_width
 	sta zp_colourline
 	bcc +
+	inc zp_screenline + 1
 	inc zp_colourline + 1
-+	
++
 	lda .scroll_load_screen + 1
 	clc
 	adc s_screen_width
 	sta .scroll_load_screen + 1
-	sta .scroll_load_screen_2 + 1
-	bcc +
-	inc .scroll_load_screen + 2
-	inc .scroll_load_screen_2 + 2
-+
-	lda .scroll_load_colour + 1
-	clc
-	adc s_screen_width
 	sta .scroll_load_colour + 1
+	sta .scroll_load_screen_2 + 1
 	sta .scroll_load_colour_2 + 1
 	bcc +
+	inc .scroll_load_screen + 2
 	inc .scroll_load_colour + 2
+	inc .scroll_load_screen_2 + 2
 	inc .scroll_load_colour_2 + 2
 +
  	jmp -


### PR DESCRIPTION
I've taken techniques from the data movement part of my smooth-scrolling code and applied them to optimize the scrolling in screenkernal.asm.  (This does not add smooth scrolling, but speeds up the regular jump-scrolling.)

Four phases of optimization are applied (described below).  Each phase of optimization is represented in a separate commit in this PR.  If preferred I could submit each as a separate PR instead (though not all at once since they affect the same code).  The phases are not strictly dependent on one another.

Calculations and measurements assume a 40x25 screen with a one-line status line for reference, but the code is not limited to this configuration.  These estimates use the minimum cycles for each instruction, except for the loop branch which is always taken.

* Move two characters per inner (column) loop iteration.
The loop branch (`bpl`) costs 3 cycles.  Using half the iterations saves 60 cycles per row, at the cost of updating the additional addresses once per row.
save: 1380 cycles
cost:  460 cycles (2 more `sta`+`inc` per row)
cost:   16 cycles (additional initialization)
net:  -904 cycles

* Assume that screen (`SCREEN_ADDRESS`) and color (`COLOUR_ADDRESS`) memory both start on page boundaries.
This means that the low byte value is always the same for corresponding screen and color addresses, allowing for some consolidation of updating color addresses.
save:  506 cycles (22 per row)
save:    3 cycles (initialization)
cost:    0 cycles
net:  -503 cycles

* Use `STA $nnnn,Y` instead of `STA ($nn),Y`.
The zero page indirect indexed instruction costs an additional clock cycle.  The change saves 80 cycles per row, at the cost of having to update the `sta` addresses in the outer loop.  
save: 1840 cycles (1*4*20 per row)
cost:  299 cycles (40 per row for additional lda/sta, less 27/row from zp updates)
cost:   41 cycles (additional initialization)
net: -1500 cycles

* Eliminate the additional `dey` (2 cycles) in the inner loop.
The first optimization moved two consecutive characters during each iteration, doubling the loop work to cut the iterations in half.  By dividing the line in half and handling the addresses separately, the extra decrement can be removed at the cost of additional address maintenance in the outer loop.
save:  920 cycles (2*20 per row)
cost:  460 cycles (20 per row)
cost:   12 cycles (initialization)
net:  -448 cycles

The cumulative estimate using the above numbers is 3355 cycles saved.  The net estimate of analyzing the final code state is 3407 cycles.  In actual measurements using VICE (disabling interrupts and waiting for a specific raster line to get consistency) the difference was 3868 cycles, including VIC bad lines.  Accounting for bad lines it should be about 3567 execution cycles.
The interpreter size increased 98 bytes.
