### PR TITLE
Smooth-scrolling initial demo

### DIFF
--- a/asm/disk.asm
+++ b/asm/disk.asm
@@ -128,6 +128,10 @@ readblock
 	; set values in readblocks_* before calling this function
 	; register a,x,y
 
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
+
 !ifdef TRACE_FLOPPY {
 	jsr print_following_string
 	!pet "Readblock: ",0
@@ -402,7 +406,7 @@ read_track_sector
 	sta zp_mempos + 1
 
 	ldy #$00
--   jsr kernal_readchar ; call CHRIN (get a byte from file)
+-	jsr kernal_readchar ; call CHRIN (get a byte from file)
 	sta (zp_mempos),Y   ; write byte to memory
 	iny
 	bne -         ; next byte, end when 256 bytes are read
@@ -498,6 +502,9 @@ print_insert_disk_msg
 	lda #>insert_msg_3
 	ldx #<insert_msg_3
 	jsr printstring_raw
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	;jsr kernal_readchar ; this shows the standard kernal prompt (not good)
 -	jsr kernal_getchar
 	beq -
@@ -589,7 +596,7 @@ z_ins_restart
 	lda #$17
 	sta reg_screen_char_mode
 
-	sei
+	+disable_interrupts
 	lda #$37
 	sta $01
 	lda #0
@@ -598,7 +605,7 @@ z_ins_restart
 	taz
 	map
 	eom
-	cli
+	+enable_interrupts
 
 	lda #>$0400 		; Make sure screen memory set to sensible location
 	sta $0288		; before we call screen init $FF5B
@@ -609,7 +616,7 @@ z_ins_restart
 }
 
 ;!ifndef TARGET_MEGA65 {
-	sei
+	+disable_interrupts
 	cld
 !ifdef TARGET_C128 {
 	lda #0
@@ -618,7 +625,7 @@ z_ins_restart
 	jsr $ff8a ; restor (Fill vector table at $0314-$0333 with default values)
 	jsr $ff84 ; ioinit (Initialize CIA's, SID, memory config, interrupt timer)
 	jsr $ff81 ; scinit (Initialize VIC; set nput/output to keyboard/screen)
-	cli
+	+enable_interrupts
 !ifdef TARGET_C128 {
 	sta c128_mmu_load_pcra
 }
@@ -731,6 +738,9 @@ z_ins_save
 	; return: x = number of characters read
 	;         .inputstring: null terminated string read (max 20 characters)
 	; modifies a,x,y
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr turn_on_cursor
 	lda #0
 	sta .inputlen
@@ -832,6 +842,10 @@ list_save_files
 	lda zp_screenline + 1
 	sta .base_screen_pos + 1
 
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
+
 	; open the channel file
 !ifdef TARGET_C128 {
 	lda #$00
@@ -848,8 +862,9 @@ list_save_files
 +   ldy #0      ; secondary address 2
 	jsr kernal_setlfs ; call SETLFS
 	jsr kernal_open     ; call OPEN
-	bcs disk_error    ; if carry set, the file could not be opened
-
+	bcc +             ; if carry set, the file could not be opened
+	jmp disk_error    ; if carry set, the file could not be opened
++
 	ldx #2      ; filenumber 2
 	jsr kernal_chkin ; call CHKIN (file 2 now used as input)
 
@@ -860,6 +875,9 @@ list_save_files
 	bne -
 
 .read_next_line	
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	lda #0
 	sta zp_temp + 1
 	; Read row pointer
@@ -1339,6 +1357,9 @@ save_game
 	lda #>.save_msg
 	ldx #<.save_msg
 	jsr printstring_raw
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 
 	; Erase old file, if any
 !ifdef TARGET_C128 {
@@ -1390,6 +1411,9 @@ save_game
 .m65_save_count = 	z_temp + 8 ; 2 bytes
 
 do_restore
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 !ifdef TARGET_MEGA65 {
 	jsr close_io
 
@@ -1503,6 +1527,9 @@ do_restore
 } ; Not TARGET_MEGA65
 
 do_save
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 !ifdef TARGET_MEGA65 {
 	jsr close_io
 
@@ -1750,12 +1777,12 @@ wait_a_sec
 ; Delay ~1.2 s so player can read the last text before screen is cleared
 	ldx #60
 .wait_any_jiffies
-	sei
+	+disable_interrupts
 	stx $0a1d ; Timer
 	ldx #0
 	stx $0a1e
 	stx $0a1f
-	cli
+	+enable_interrupts
 -	bit $0a1f
 	bpl -
 	; ldx #40 ; How many frames to wait

--- a/asm/memory.asm
+++ b/asm/memory.asm
@@ -175,7 +175,7 @@ get_page_at_z_pc_did_pha
 !ifdef TARGET_C128 {
 copy_page_c128_via_reu
 
-	sei
+	+disable_interrupts
 	stx .load_bank_again + 1
 	sty .load_dest_page + 1
 
@@ -252,7 +252,7 @@ copy_page_c128_via_reu
 	and #%00111111
 	sta $d506
 
-	cli
+	+enable_interrupts
 	jmp restore_2mhz
 
 copy_page_c128_src
@@ -287,7 +287,7 @@ copy_page_c128_src
 	lda #0
 	sta reg_2mhz	;CPU = 1MHz
 
-+	sei
++	+disable_interrupts
 	sta c128_mmu_load_pcrb,x
 -   ldy #0
 .copy
@@ -296,7 +296,7 @@ copy_page_c128_src
 	iny
 	bne .copy
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 !if SUPPORT_REU = 1 {
@@ -315,7 +315,7 @@ read_word_from_far_dynmem
 ; y retains its value
 	sta .read_word + 1
 	sta .read_word_2 + 1
-	sei
+	+disable_interrupts
 	sta c128_mmu_load_pcrc
 	iny
 .read_word
@@ -325,7 +325,7 @@ read_word_from_far_dynmem
 .read_word_2
 	lda ($fb),y
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 write_word_to_far_dynmem
@@ -334,7 +334,7 @@ write_word_to_far_dynmem
 ; a,x = value (byte 1, byte 2)
 ; y = offset from address in zp vector
 ; y is increased by 1
-	sei
+	+disable_interrupts
 	sta c128_mmu_load_pcrc
 .write_word
 	sta ($fb),y
@@ -343,7 +343,7 @@ write_word_to_far_dynmem
 .write_word_2
 	sta ($fb),y
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 write_word_far_dynmem_zp_1 = .write_word + 1
@@ -363,14 +363,14 @@ copy_page
 	sta .cp_dma_source_address + 1
 	sty .cp_dma_dest_address + 1
 	ldy #0
-	sei
+	+disable_interrupts
 	jsr mega65io
 	sty $d702 ; DMA list is in bank 0
 	lda #>.cp_dma_list
 	sta $d701
 	lda #<.cp_dma_list
 	sta $d705 
-	cli
+	+enable_interrupts
 	clc
 	rts
 	
@@ -444,7 +444,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 }
 	sta .copy + 2
 	sty .copy + 5
-	sei
+	+disable_interrupts
 	+set_memory_all_ram_unsafe
 	+before_dynmem_read
 -   ldy #0
@@ -455,7 +455,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	bne .copy
 	+after_dynmem_read
 	+set_memory_no_basic_unsafe
-	cli
+	+enable_interrupts
 	rts
 
 !if SUPPORT_REU = 1 {
@@ -468,7 +468,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	jsr store_reu_transfer_params
 	lda #%10100000;  c64 -> REU with delayed execution
 	sta reu_command
-	sei
+	+disable_interrupts
 	+set_memory_all_ram_unsafe
 	+before_dynmem_read
 	lda $ff00
@@ -487,7 +487,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	sta $ff00
 	+after_dynmem_read
 	+set_memory_no_basic_unsafe
-	cli
+	+enable_interrupts
 
 	rts
 }

--- a/asm/ozmoo.asm
+++ b/asm/ozmoo.asm
@@ -995,9 +995,9 @@ game_id		!byte 0,0,0,0
 	sta $d011
 	lda #251 ; low raster bit (1 raster beyond visible screen)
 	sta $d012
+	cli
 ++
 }
-	cli
 
 !ifdef SCROLLBACK {
 	lda scrollback_supported
@@ -1026,6 +1026,9 @@ game_id		!byte 0,0,0,0
 
 
 ; include other assembly files
+!ifndef NOSMOOTHSCROLL {
+!source "smoothscroll.asm"
+}
 !source "utilities.asm"
 !ifdef SCROLLBACK {
 !source "scrollback.asm"

--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -229,7 +229,7 @@ init_mega65
 	
 colour2k
 	; start mapping 2nd KB of colour RAM to $DC00-$DFFF
-	sei
+	+disable_interrupts
 	pha
 	jsr mega65io
 	lda #$01
@@ -244,7 +244,7 @@ colour1k
 	lda #$00
 	sta $d030
 	pla
-	cli
+	+enable_interrupts
 	rts
 }
 
@@ -774,6 +774,13 @@ s_scrolled_lines !byte 0
 }
 !ifdef TARGET_MEGA65 {
 	jsr colour2k	
+}
+!ifndef NOSMOOTHSCROLL {
+	lda smoothscrolling
+	beq +
+	jsr smoothscroll
+	jmp .done_scrolling
++
 }
 	ldx window_start_row + 1 ; how many top lines to protect
 	stx zp_screenrow

--- a/asm/smoothscroll.asm
+++ b/asm/smoothscroll.asm
@@ -1,0 +1,458 @@
+!zone smoothscroll {
+
+; When 1, smooth scrolling is active.
+; Call smoothscroll_off and smoothscroll_on to change it.
+smoothscrolling	!byte 0
+
+; how many top lines to protect
+.reserve = window_start_row + 1
+
+;-------------------
+; storage for internal "variables"
+.smoothmode !byte 0     ; 1 = enabled
+.init_done !byte 0
+.screen_width_half !byte 0
+.vicmode !byte $00      ; original value of VIC mode-bits from $d011
+.filled  !byte $00      ; temporary storage for VIC idle-mode value
+.orgscrl !byte $00      ; original fine-scroll value
+.shifted !byte $00      ; count of all line shifts on the screen so far
+.fld     !byte $00      ; raster lines to move text down during the frame
+
+; table of screen row address offsets, 2 bytes per entry (lo, hi)
+.rowoffset	!fill SCREEN_HEIGHT * 2, 0
+
+;-------------------
+; Initialization (called automatically when smoothscroll is first enabled)
+.init
+	lda s_screen_width
+	lsr
+	sta .screen_width_half
+
+	; build the .rowoffset table
+	ldx #$00
+-	inx
+	inx
+	lda .rowoffset-2,x      ; previous lb
+	clc
+	adc s_screen_width
+	sta .rowoffset,x        ; lb
+	lda .rowoffset-1,x      ; previous hb
+	adc #0
+	sta .rowoffset+1,x      ; hb
+	txa
+	lsr
+	cmp s_screen_height_minus_one
+	bne -
+	inc .init_done
+	rts
+
+;-------------------
+; Enable/disable smooth scrolling
+toggle_smoothscroll
+	lda .smoothmode
+	eor #$01
+	sta .smoothmode
+	sta smoothscrolling
+	beq ++
+
+	; Enable
+	lda .init_done
+	bne +
+	jsr .init
++	jmp .enable_irq
+
+++	; Disable
+	; wait for in-progress smooth scroll
+-	lda .fld
+	bne -
+
+	sei
+	
+	; disable raster interrupt
+	lda $d01a
+	and #$fe
+	sta $d01a
+
+	; enable CIA#1 timer A IRQ (keyboard)
+	lda #$81
+	sta $dc0d
+
+	; restore original IRQ vector
+	lda .vector + 1
+	sta $0314
+	lda .vector + 2
+	sta $0315
+
+	cli
+	rts
+
+;-------------------
+; Wait for any in-progress smooth-scrolling to complete.
+wait_smoothscroll
+	pha
+	lda smoothscrolling
+	beq +++
+-	lda .fld
+	bne -
++++	pla
+	rts
+
+;-------------------
+; Activate smooth scrolling, if enabled
+smoothscroll_on
+	pha
+	lda .smoothmode
+	beq +++
+	lda smoothscrolling
+	bne +++
+	inc smoothscrolling
++++	pla
+	rts
+
+;-------------------
+; Deactivate smooth scrolling
+smoothscroll_off
+	pha
+	lda smoothscrolling
+	beq +++
+
+	; wait for in-progress smooth scroll
+-	lda .fld
+	bne -
+
+	dec smoothscrolling
+
+	; reset scroll position just in case it's wrong
+	lda .orgscrl
+	ora .vicmode
+	sta $d011
+
++++	pla
+	rts
+
+;-------------------
+disable_smoothscroll
+	pha
+	lda .smoothmode
+	beq +++
+	jsr toggle_smoothscroll
++++	pla
+	rts
+
+;-------------------
+enable_smoothscroll
+	pha
+	lda .smoothmode
+	bne +++
+	jsr toggle_smoothscroll
++++	pla
+	rts
+
+;-------------------
+; Scroll the screen by one text line.
+smoothscroll
+	; The loop addresses are stale and must be reinitialized.
+	ldy #>SCREEN_ADDRESS
+	sty .chrdst + 2
+	sty .chrsrc + 2
+	sty .chrdst + 8
+	sty .chrsrc + 8
+	ldy #>COLOUR_ADDRESS
+	sty .clrdst + 2
+	sty .clrsrc + 2
+	sty .clrdst + 8
+	sty .clrsrc + 8
+
+	lda .reserve
+	asl
+	tax
+	lda .rowoffset,x
+	sta .chrdst + 1
+	sta .clrdst + 1
+	clc
+	adc .screen_width_half
+	sta .chrdst + 7
+	sta .clrdst + 7
+	adc .screen_width_half
+	sta .chrsrc + 1
+	sta .clrsrc + 1
+	adc .screen_width_half
+	sta .chrsrc + 7
+	sta .clrsrc + 7
+
+	; wait for in-progress smooth scroll
+-	lda .fld
+	bne -
+	lda smoothscrolling
+	beq ++
+	; wait for raster to pass the reserved area
+	lda .reserve
+	asl
+	asl
+	asl
+	adc #51
+-	cmp $d012
+	bne -
+	; skip the mid-screen interrupt(s)
+	lda #0
+	sta $d012
+
+	; set up smooth scroll offset
+	lda #7
+	sta .fld
+++
+	; move screen data (jump-scroll)
+	lda s_screen_height_minus_one
+	sec
+	sbc .reserve
+	tax
+.dorows ldy .screen_width_half
+	dey
+.docols
+.chrsrc lda SCREEN_ADDRESS,y
+.chrdst sta SCREEN_ADDRESS,y
+	lda SCREEN_ADDRESS,y
+	sta SCREEN_ADDRESS,y
+.clrsrc lda COLOUR_ADDRESS,y
+.clrdst sta COLOUR_ADDRESS,y
+	lda COLOUR_ADDRESS,y
+	sta COLOUR_ADDRESS,y
+	dey
+	bpl .docols
+
+	; advance dst & src addresses
+	ldy #6
+.loop   lda .chrsrc+1,y
+	sta .chrdst+1,y
+	sta .clrdst+1,y
+	clc
+	adc s_screen_width
+	sta .chrsrc+1,y
+	sta .clrsrc+1,y
+	lda .chrsrc+2,y
+	sta .chrdst+2,y
+	lda .clrsrc+2,y
+	sta .clrdst+2,y
+	bcc .nocary
+	adc #0
+	sta .clrsrc+2,y
+	lda .chrsrc+2,y
+	adc #1
+	sta .chrsrc+2,y
+.nocary tya
+	sec
+	sbc #6
+	tay
+	bpl .loop
+	dex
+	bne .dorows
+
+	; clear bottom row
+	lda .chrdst + 2
+	sta .clear + 2
+	lda .chrdst + 1
+	sta .clear + 1
+	lda #$20 ; space
+	ldy s_screen_width_minus_one
+.clear  sta $0000,y
+	dey
+	bpl .clear
+	rts
+
+;-------------------
+; Set up and enable the raster interrupt.
+.enable_irq
+	sei
+
+	; Wait until off-screen to avoid a brief visual glitch.
+-	lda $d012
+	bne -
+
+	lda $d01a       ; enable raster interrupts
+	ora #$01
+	sta $d01a
+
+	lda #$7f
+	sta $dc0d       ; disable CIA#1 interrupts
+
+	lda $d011       ; trigger at top of screen
+	and #$7f
+	sta $d011
+	and #$f8        ; save vic mode
+	sta .vicmode
+	lda #$00
+	sta $d012
+
+	lda $d011       ; save original finescroll
+	and #$07
+	sta .orgscrl
+
+	lda $0315
+	cmp #>.vidirq
+	beq .skip
+
+	lda $0314       ; save existing interrupt vector
+	sta .vector + 1
+	lda $0315
+	sta .vector + 2
+
+	lda #<.vidirq   ; change the interrupt vector
+	sta $0314
+	lda #>.vidirq
+	sta $0315
+
+.skip   cli
+	rts
+
+;-------------------
+; Raster interrupt routine
+.vidirq
+	; we have 19-27 cycles until raster line advances
+	; 8 cycles
+	lda $d019       ; triggered by raster position?
+	and #$01
+	beq .vector
+
+	; 9 cycles
+	ldx $d012
+	cpx #246
+	bcc +
+	jmp .fillbottom
++
+	; 5 cycles
+	; An extra do-nothing interrupt mid-screen allows more closely
+	; matching (on average) the 60/sec average kernal interrupt
+	; schedule, for games which use the clock.
+	cpx #150
+	bcc +
+	ldx #0          ; next interrupt raster
+	beq .setirq
++
+	; 5 cycles (to .effect)
+	cpx #48
+	bcs .effect
+
+.tos	lda .orgscrl    ; top of screen--set default scroll
+	ora .vicmode
+	sta $d011
+	ldx #150        ; next interrupt raster if nothing to do
+
+	lda .fld
+	beq .setirq     ; nothing to do
+	dec .fld
+	beq .setirq     ; done--nothing to do
+	lda #0
+	sta .shifted
+
+	; Calculate the raster line to interrupt.
+	; The target line to modify is 48+Yscroll+reserve*8.
+	; We need to interrupt 3 lines before that, in order to:
+	; 1. use the remaining time in the interrupted line
+	; 2. use some of the next line (#1 is not enough time)
+	; 3. wait for the start of the next line in order to avoid causing
+	;    visual artifacts.
+	; The modification finally takes effect on the next line.
+	lda .reserve
+	asl
+	asl
+	asl
+	adc #45
+	adc .orgscrl
+	tax
+.setirq
+	stx $d012
+	lda #$01	; unlatch raster IRQ flag
+	sta $d019
+	lda #$7f
+	sta $dc0d       ; disable CIA#1 IRQ (in case it's been re-enabled)
+
+	lda $dc0d       ; need a kernal interrupt?
+	beq .return
+.vector jmp $ea31
+
+.effect
+	; 8 cycles
+	ldy .fld
+	; The regular TOS interrupt can get delayed to an unexpected time
+	; during disk I/O, so check for this and avoid doing anything..
+	beq .reset
+	iny
+
+	; 14 cycles
+	lda .filler
+	sta .filled
+	lda #$00
+	sta .filler
+
+	; 4 cycles
+	ldx $d012
+
+	; 8 cycles
+.next   txa
+	and #$07        ; prevent vic badline
+	ora .vicmode
+
+-	cpx $d012       ; wait for next line
+	beq -
+
+	; 4 cycles
+	sta $d011
+
+	; 11 cycles
+	inx
+	cpx #$f7        ; f7 is last possible badline
+	bcs +
+	dey
+	bne .next
+
+	; 14 cycles
++	inx	        ; set up badline condition
+	txa
+	and #$07
+	ora .vicmode
+	sta $d011
+
+	; 22 cycles
+	lda .shifted
+	clc
+	adc .fld
+	bcc +
+	lda #$f0
++	sta .shifted
+
+	; 8 cycles
+	lda .filled     ; restore the fill value
+	sta .filler
+
+.reset  lda #246
+.nextirq
+	sta $d012
+
+	lda #$01        ; unlatch raster IRQ flag
+	sta $d019
+
+.return	pla             ; restore Y, X, A
+	tay
+	pla
+	tax
+	pla
+	rti
+
+.fillbottom
+	; Prevent garbage in the "gap" at the bottom of the
+	; screen which exists at certain scroll positions.
+	ldx .filler
+	lda #$00
+	sta .filler
+
+	lda #250
+-	cmp $d012
+	bcs -
+
+	stx .filler
+	lda #0
+	jmp .nextirq
+
+.filler = SCREEN_ADDRESS + $3bff    ; =$3fff
+} ; zone smoothscroll
+

--- a/asm/splashlines.tpl
+++ b/asm/splashlines.tpl
@@ -8,27 +8,12 @@ splashline3
 	!pet "@3s@", 0
 splashline4
 	!pet "               Ozmoo @vs@",0
-
 splashline5
-!ifndef NODARKMODE {
-	!ifdef SCROLLBACK {
-		!pet "        F1=Darkmode F5=Scrollback",0
-	} else {
-		!pet "               F1=Darkmode",0
-	}
-} else {
-	!ifdef SCROLLBACK {
-		!pet "              F5=Scrollback",0
-	} else {
-		!pet " ",0
-	}
-}
-splashline6
 	!pet "   Ctrl: D=Reset device# R=Repeat keys",0
-splashline7
+splashline6
 	!pet "            0-3=Scroll delay",0
 
 
 splash_index_col
-	!byte @0c@, @1c@, @2c@, @3c@, 0, 0, 0, 0
+	!byte @0c@, @1c@, @2c@, @3c@, 0, 0, 0
 

--- a/asm/splashscreen.asm
+++ b/asm/splashscreen.asm
@@ -1,9 +1,32 @@
 !zone splash_screen {
 splash_screen
+!ifndef NODARKMODE {
+	inc .fkey_count
+}
+!ifndef NOSMOOTHSCROLL {
+	inc .fkey_count
+}
+!ifdef SCROLLBACK {
+	inc .fkey_count
+}
 	ldy #0
 	sty z_temp ; String number currently printing
 splash_line_y
 	ldx splash_index_line,y
+	cpx .title_line
+	bne ++
+	; move the title up to insert F-keys
+	ldx .fkey_count
+	inx
+	txa
+	lsr
+	tax
+	beq +
+-	dec .title_line
+	dex
+	bne -
+	ldx .title_line
+++
 	lda splash_index_col,y
 !ifdef TARGET_C128 {
 	ldy COLS_40_80
@@ -24,8 +47,13 @@ splash_line_y
 	jsr printstring_raw
 	inc z_temp
 	ldy z_temp
-	cpy #8
+	cpy #7
 	bne splash_line_y
+
+	lda .fkey_count
+	beq +
+	jsr .splash_fkeys
++
 
 .restart_timer
 	lda ti_variable + 2
@@ -62,15 +90,130 @@ splash_line_y
 	jmp .restart_timer
 +
 }
+!ifndef NOSMOOTHSCROLL {
+	cpy #137 ; F2
+	bne +
+	jsr toggle_smoothscroll
+	jmp .restart_timer
++
+}
 	lda #147
 	jmp s_printchar
+
+.splash_fkeys
+	ldy #0
+	sty z_temp ; String number currently printing
+.fkey_msg
+	; compute the column
+	lda s_screen_width
+	sec
+	sbc #40
+	lsr
+	tax ; amount to add if screen > 40 columns
+
+	lda .fkey_count
+	cmp #1
+	beq ++
+	; multiple F-keys; arrange in 2 columns
+	clc
+	lda z_temp
+	and #$01
+	beq +
+	; 2nd column
+	txa
+	adc #20
+	tax
++	txa
+	adc #3
+	bne +++ ; always
+++
+	; only one F-key, so center it
+	ldy z_temp
+	ldx .fkey_index_lb,y
+	lda .fkey_index_hb,y
+	jsr .center
++++
+	tay
+
+	; compute the line
+	lda z_temp
+	lsr
+	clc
+	adc .title_line
+	tax
+	inx
+	inx
+
+	; print the string
+	jsr set_cursor
+	ldy z_temp
+	ldx .fkey_index_lb,y
+	lda .fkey_index_hb,y
+	jsr printstring_raw
+	inc z_temp
+	ldy z_temp
+	cpy .fkey_count
+	bne .fkey_msg
+	rts
+
+.center
+; Prepare to center a message on the screen
+; Parameters: Address in A,X to 0-terminated string
+; Returns: Starting column in A
+	stx .read_byte + 1
+	sta .read_byte + 2
+	ldx #0
+.read_byte
+	lda $8000,x
+	beq +
+	inx
+	bne .read_byte
++	stx .length
+	lda s_screen_width
+	sec
+	sbc .length
+	lsr
+	rts
+
+!ifndef NODARKMODE {
+.fkey1 !pet "F1=Darkmode", 0
+}
+!ifndef NOSMOOTHSCROLL {
+.fkey2 !pet "F2=Smoothscroll", 0
+}
+!ifdef SCROLLBACK {
+.fkey5 !pet "F5=Scrollback", 0
+}
+.fkey_index_lb
+!ifndef NODARKMODE {
+	!byte <.fkey1
+}
+!ifndef NOSMOOTHSCROLL {
+	!byte <.fkey2
+}
+!ifdef SCROLLBACK {
+	!byte <.fkey5
+}
+.fkey_index_hb
+!ifndef NODARKMODE {
+	!byte >.fkey1
+}
+!ifndef NOSMOOTHSCROLL {
+	!byte >.fkey2
+}
+!ifdef SCROLLBACK {
+	!byte >.fkey5
+}
+.fkey_count !byte 0
+.title_line !byte 21
+.length
 
 !source "splashlines.asm"
 
 splash_index_line
-	!byte 2, 4, 6, 8, 20, 22, 23, 24
+	!byte 2, 4, 6, 8, 21, 23, 24
 splash_index_lb
-	!byte <splashline0, <splashline1, <splashline2, <splashline3, <splashline4, <splashline5, <splashline6, <splashline7
+	!byte <splashline0, <splashline1, <splashline2, <splashline3, <splashline4, <splashline5, <splashline6
 splash_index_hb
-	!byte >splashline0, >splashline1, >splashline2, >splashline3, >splashline4, >splashline5, >splashline6, >splashline7
+	!byte >splashline0, >splashline1, >splashline2, >splashline3, >splashline4, >splashline5, >splashline6
 }	

--- a/asm/text.asm
+++ b/asm/text.asm
@@ -1012,6 +1012,9 @@ update_read_text_timer
 
 getchar_and_maybe_toggle_darkmode
 	stx .getchar_save_x
+!ifndef NOSMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_getchar
 !ifndef NODARKMODE {
  	cmp #133 ; Charcode for F1
@@ -1019,6 +1022,13 @@ getchar_and_maybe_toggle_darkmode
 	jsr toggle_darkmode
 	jmp .did_something
 +	
+}
+!ifndef NOSMOOTHSCROLL {
+	cmp #137 ; F2
+	bne +
+	jsr toggle_smoothscroll
+	jmp .did_something
++
 }
 !ifdef SCROLLBACK {
 	cmp #135 ; F5

--- a/asm/utilities.asm
+++ b/asm/utilities.asm
@@ -40,14 +40,14 @@ plus4_enable_rom = $ff3e
 
 !macro before_dynmem_read {
 !ifdef TARGET_PLUS4 {
-	sei
+	+disable_interrupts
 	sta plus4_enable_ram
 }
 }
 !macro after_dynmem_read {
 !ifdef TARGET_PLUS4 {
 	sta plus4_enable_rom
-	cli
+	+enable_interrupts
 }
 }
 
@@ -127,11 +127,17 @@ plus4_enable_rom = $ff3e
 
 ; to be expanded to disable NMI IRQs later if needed
 !macro disable_interrupts {
+!ifndef NOSMOOTHSCROLL {
+	jsr smoothscroll_off
+}
 	sei 
 }
 
 !macro enable_interrupts {
 	cli
+!ifndef NOSMOOTHSCROLL {
+	jsr smoothscroll_on
+}
 }
 
 
@@ -150,11 +156,11 @@ plus4_enable_rom = $ff3e
 read_next_byte_at_z_pc_sub
 	ldy #0
 !ifdef TARGET_PLUS4 {
-	sei
+	+disable_interrupts
 	sta plus4_enable_ram
 	lda (z_pc_mempointer),y
 	sta plus4_enable_rom
-	cli
+	+enable_interrupts
 } else {
 !ifdef SKIP_BUFFER {
 	+disable_interrupts


### PR DESCRIPTION
This form of the code is not meant to be merged.  It is an early version of smooth-scrolling code posted for illustration and discussion as mentioned in issue #50.

The make.rb changes follow the example of "dark mode".  The feature is included by default for target `c64`, explicitly included with `-smooth` or `-smooth:1`, or explicitly excluded with `smooth:0`.  It is inactive until turned on using the `F2` key.

The code for the feature is in smoothscroll.asm.  Key parts are:
- `smoothscroll` scrolls the screen, corresponding to what `.scroll` does in screenkernal.asm.
- `.vidirq` is the raster interrupt routine, which performs scrolling as directed by the value of `.fld` and `.reserve` (which is just an alias for `window_start_row + 1`).

Places where interrupts are disabled explicitly (`sei`) or could be disabled by a kernal routine are updated to avoid doing so in the middle of scrolling.

The splashscreen changes were to explore something different than explicitly adding a new literal string, as it started getting pretty cumbersome with three independent conditions.  I included them here for completeness.

I'll keep this description brief for now but am happy to provide more detailed information as needed.
