### PR TITLE
Smooth-scrolling feature for C64

### DIFF
--- a/asm/memory.asm
+++ b/asm/memory.asm
@@ -175,7 +175,7 @@ get_page_at_z_pc_did_pha
 !ifdef TARGET_C128 {
 copy_page_c128_via_reu
 
-	sei
+	+disable_interrupts
 	stx .load_bank_again + 1
 	sty .load_dest_page + 1
 
@@ -252,7 +252,7 @@ copy_page_c128_via_reu
 	and #%00111111
 	sta $d506
 
-	cli
+	+enable_interrupts
 	jmp restore_2mhz
 
 copy_page_c128_src
@@ -287,7 +287,7 @@ copy_page_c128_src
 	lda #0
 	sta reg_2mhz	;CPU = 1MHz
 
-+	sei
++	+disable_interrupts
 	sta c128_mmu_load_pcrb,x
 -   ldy #0
 .copy
@@ -296,7 +296,7 @@ copy_page_c128_src
 	iny
 	bne .copy
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 !if SUPPORT_REU = 1 {
@@ -315,7 +315,7 @@ read_word_from_far_dynmem
 ; y retains its value
 	sta .read_word + 1
 	sta .read_word_2 + 1
-	sei
+	+disable_interrupts
 	sta c128_mmu_load_pcrc
 	iny
 .read_word
@@ -325,7 +325,7 @@ read_word_from_far_dynmem
 .read_word_2
 	lda ($fb),y
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 write_word_to_far_dynmem
@@ -334,7 +334,7 @@ write_word_to_far_dynmem
 ; a,x = value (byte 1, byte 2)
 ; y = offset from address in zp vector
 ; y is increased by 1
-	sei
+	+disable_interrupts
 	sta c128_mmu_load_pcrc
 .write_word
 	sta ($fb),y
@@ -343,7 +343,7 @@ write_word_to_far_dynmem
 .write_word_2
 	sta ($fb),y
 	sta c128_mmu_load_pcra
-	cli
+	+enable_interrupts
 	rts
 
 write_word_far_dynmem_zp_1 = .write_word + 1
@@ -363,14 +363,14 @@ copy_page
 	sta .cp_dma_source_address + 1
 	sty .cp_dma_dest_address + 1
 	ldy #0
-	sei
+	+disable_interrupts
 	jsr mega65io
 	sty $d702 ; DMA list is in bank 0
 	lda #>.cp_dma_list
 	sta $d701
 	lda #<.cp_dma_list
 	sta $d705 
-	cli
+	+enable_interrupts
 	clc
 	rts
 	
@@ -444,7 +444,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 }
 	sta .copy + 2
 	sty .copy + 5
-	sei
+	+disable_interrupts
 	+set_memory_all_ram_unsafe
 	+before_dynmem_read
 -   ldy #0
@@ -455,7 +455,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	bne .copy
 	+after_dynmem_read
 	+set_memory_no_basic_unsafe
-	cli
+	+enable_interrupts
 	rts
 
 !if SUPPORT_REU = 1 {
@@ -468,7 +468,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	jsr store_reu_transfer_params
 	lda #%10100000;  c64 -> REU with delayed execution
 	sta reu_command
-	sei
+	+disable_interrupts
 	+set_memory_all_ram_unsafe
 	+before_dynmem_read
 	lda $ff00
@@ -487,7 +487,7 @@ write_word_far_dynmem_zp_2 = .write_word_2 + 1
 	sta $ff00
 	+after_dynmem_read
 	+set_memory_no_basic_unsafe
-	cli
+	+enable_interrupts
 
 	rts
 }

--- a/asm/ozmoo.asm
+++ b/asm/ozmoo.asm
@@ -1026,6 +1026,9 @@ game_id		!byte 0,0,0,0
 
 
 ; include other assembly files
+!ifdef SMOOTHSCROLL {
+!source "smoothscroll.asm"
+}
 !source "utilities.asm"
 !ifdef SCROLLBACK {
 !source "scrollback.asm"
@@ -1304,6 +1307,9 @@ vmem_cache_count = vmem_cache_size / 256
 stack_start
 
 deletable_screen_init_1
+!ifdef SMOOTHSCROLL {
+	jsr toggle_smoothscroll
+}
 	; start text output from bottom of the screen
 
 !ifndef Z4PLUS {

--- a/asm/reu.asm
+++ b/asm/reu.asm
@@ -145,6 +145,9 @@ copy_page_to_reu
 	clc
 	jsr store_reu_transfer_params
 
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 -	lda #%10110000;  c64 -> REU with immediate execution
 	sta reu_command
 
@@ -218,6 +221,9 @@ copy_page_from_reu
 	clc
 	jsr store_reu_transfer_params
 
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	lda #%10110001;  REU -> c64 with immediate execution
 	sta reu_command
 
@@ -509,4 +515,3 @@ print_reu_progress_bar
 	sta reu_progress_bar_updates
 
 	rts
-	

--- a/asm/screen.asm
+++ b/asm/screen.asm
@@ -286,6 +286,9 @@ z_ins_split_window
 ;    jmp split_window ; Not needed since split_window follows
 
 split_window
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	; split if <x> > 0, unsplit if <x> = 0
 	cpx #0
 	bne .split_window

--- a/asm/screenkernal.asm
+++ b/asm/screenkernal.asm
@@ -789,6 +789,12 @@ s_scrolled_lines !byte 0
 	sta .scroll_load_colour + 2
 	dec zp_screenrow
 	jsr .update_screenpos
+!ifdef SMOOTHSCROLL {
+	lda smoothscrolling
+	beq +
+	jsr smoothscroll
++
+}
 	lda s_screen_height_minus_one
 	sec
 	sbc zp_screenrow
@@ -837,6 +843,9 @@ s_scrolled_lines !byte 0
 .done_scrolling
 !ifdef TARGET_MEGA65 {
 	jsr colour1k
+}
+!ifdef SMOOTHSCROLL {
+	+done_smoothscroll
 }
 	lda s_screen_height_minus_one
 	sta zp_screenrow

--- a/asm/scrollback.asm
+++ b/asm/scrollback.asm
@@ -641,6 +641,9 @@ sb_copy_to_buffer
 		sta allow_2mhz_in_40_col
 		sta reg_2mhz	;CPU = 1MHz
 	}
+	!ifdef SMOOTHSCROLL {
+		jsr wait_smoothscroll
+	}
 		lda #%10110000;  c64 -> REU with immediate execution
 		sta reu_command
 	!ifdef TARGET_C128 {
@@ -654,7 +657,7 @@ sb_copy_to_buffer
 !ifdef TARGET_PLUS4 {
 	+before_dynmem_read
 } else {
-	sei
+	+disable_interrupts
 }
 	ldy#0
 -
@@ -699,7 +702,7 @@ sb_copy_to_buffer
 !ifdef TARGET_PLUS4 {
 	+after_dynmem_read
 } else {
-	cli
+	+enable_interrupts
 }
 	rts
 }
@@ -716,6 +719,9 @@ sb_copy_to_ram
 		sta allow_2mhz_in_40_col
 		sta reg_2mhz	;CPU = 1MHz
 	}
+	!ifdef SMOOTHSCROLL {
+		jsr wait_smoothscroll
+	}
 		lda #%10110001;  REU -> c64 with immediate execution
 		sta reu_command
 	!ifdef TARGET_C128 {
@@ -729,7 +735,7 @@ sb_copy_to_ram
 !ifdef TARGET_PLUS4 {
 	+before_dynmem_read
 } else {
-	sei
+	+disable_interrupts
 }
 	ldy#0
 -
@@ -773,7 +779,7 @@ sb_copy_to_ram
 !ifdef TARGET_PLUS4 {
 	+after_dynmem_read
 } else {
-	cli
+	+enable_interrupts
 }
 	rts
 }
@@ -787,6 +793,9 @@ sb_fill_buffer
 		jsr sb_copy_params_to_reu
 		lda #$80
 		sta reu_control ; Fix C64 address
+	!ifdef SMOOTHSCROLL {
+		jsr wait_smoothscroll
+	}
 		lda #%10110000;  c64 -> REU with immediate execution
 		sta reu_command
 		rts
@@ -797,7 +806,7 @@ sb_fill_buffer
 !ifdef TARGET_PLUS4 {
 	+before_dynmem_read
 } else {
-	sei
+	+disable_interrupts
 }
 	ldy #0
 !ifdef TARGET_C128 {
@@ -825,7 +834,7 @@ sb_fill_buffer
 !ifdef TARGET_PLUS4 {
 	+after_dynmem_read
 } else {
-	cli
+	+enable_interrupts
 }
 	rts
 }
@@ -870,6 +879,9 @@ copy_line_to_scrollback
 .do_copy
 	sta sb_copy_ram
 	jsr sb_copy_to_buffer
+;!ifdef SMOOTHSCROLL {
+;	jsr wait_smoothscroll
+;}
 ;	lda #%10110000;  c64 -> REU with immediate execution
 ;	sta reu_command
 
@@ -990,6 +1002,9 @@ launch_scrollback
 	sta sb_copy_len + 1
 	; lda zp_screenline
 	; sta reu_c64base
+;!ifdef SMOOTHSCROLL {
+;	jsr wait_smoothscroll
+;}
 ;	lda #%10110000;  c64 -> REU with immediate execution
 ;	sta reu_command
 	jsr sb_copy_to_buffer

--- a/asm/smoothscroll.asm
+++ b/asm/smoothscroll.asm
@@ -1,0 +1,330 @@
+!zone smoothscroll {
+
+; When $ff, smooth scrolling is active (0 = inactive).
+; Call smoothscroll_off and smoothscroll_on to change it.
+smoothscrolling !byte 0
+
+; When $ff, we're in a critical timing phase and shouldn't do potentially
+; expensive things such as calling the kernal's IRQ handler.
+smoothcritical !byte 0
+
+; The last addressable byte of the VIC-II's 16KB bank is used as the
+; pixel data value in idle state.
+.filler = SCREEN_ADDRESS & $c000 | $3fff
+
+; how many top lines to protect (address containing the status area size)
+.reserve = window_start_row + 1
+
+;--------------------
+; key raster positions
+.raster_top =  48   ; base top of screen (first text raster when Yscroll=0)
+.raster_bot !byte 0 ; earliest interrupt line for bottom-of-screen handling
+.raster_border !byte 0 ; first raster line of bottom border (computed)
+
+;--------------------
+; storage for internal variables
+.smoothmode !byte 0     ; $ff = smooth-scrolling enabled (0 = disabled)
+.vicmode !byte $00      ; original value of VIC-II mode-bits from $d011
+.orgscrl !byte $00      ; original fine-scroll value
+.fld     !byte $ff      ; lines to shift text down during the frame, -1
+.irqline !byte 0        ; current raster IRQ line when scrolling
+
+;--------------------
+; Wait for any in-progress smooth-scrolling to complete.
+; This should be called before any activity which could disable
+; interrupts, to avoid irregular screen movement.
+; If printing to the screen (and thus scrolling) might occur while
+; interrupts are disabled, use smoothscroll_off instead.
+wait_smoothscroll
+-	bit .fld
+	bpl -
+	rts
+
+;--------------------
+; Activate smooth scrolling, if enabled.
+; Call this to turn on smooth scrolling again after calling
+; smoothscroll_off.
+smoothscroll_on
+	bit .smoothmode
+	bpl +
+	dec smoothscrolling
++	rts
+
+;--------------------
+; Deactivate smooth scrolling.
+; Call this to temporarily turn off smooth scrolling, usually in
+; preparation to disable interrupts while still keeping it safe to
+; print to the screen.
+; If printing will not occur, wait_smoothscroll can be used instead.
+smoothscroll_off
+	bit smoothscrolling
+	bpl +
+	jsr wait_smoothscroll
+	inc smoothscrolling
++	rts
+
+;--------------------
+; Put the "smooth" in scrolling.
+; This should be called just before moving screen data.
+smoothscroll
+	jsr wait_smoothscroll
+
+	ldx #0 ; skip interrupts until the next frame
+	ldy #6 ; smooth-scroll offset (7 - 1)
+
+	; A SuperCPU in fast mode can easily move all the data
+	; while off-screen.  ($D0B8 bit 6 indicates 1MHz vs. fast mode.)
+	; http://www.elysium.filety.pl/tools/supercpu/superprog.html
+	; wait_smoothscroll will typically release at .raster_border, with
+	; the next frame needing to be drawn before scrolling again.  So
+	; wait for .raster_bot (which is higher) in order to let that happen.
+	lda .raster_bot
+	bit $d0b8
+	bvc +
+
+	; wait for raster to pass the reserved area
+	lda .reserve
+	asl
+	asl
+	asl
+	adc #.raster_top
+	adc .orgscrl
++
+-	cmp $d012
+	bne -
+	bit $d011
+	bmi -
+
+	stx $d012
+	dex
+	stx smoothcritical
+
+	sty .fld
+	rts
+
+;--------------------
+; This should be used after moving screen data.
+!macro done_smoothscroll {
+	lda #0
+	sta smoothcritical
+}
+
+;--------------------
+; Enable/disable smooth scrolling.
+; Call this to switch the enabled state (at the user's request).
+; (See smoothscroll_off for the program's own needs.)
+toggle_smoothscroll
+	lda .smoothmode
+	eor #$ff
+	sta .smoothmode
+	sta smoothscrolling
+	bne +
+	; Disable
+	jmp wait_smoothscroll
+
++	; Enable
+	lda .raster_border
+	bne +++
+	; Calculate the bottom border position.
+	lda s_screen_height
+	asl
+	asl
+	asl
+	adc #.raster_top
+	tax
+	dex
+	stx .raster_bot
+	adc #3
+	sta .raster_border
+
+	sei
+
+	lda #$7f        ; disable CIA#1 interrupts
+	sta $dc0d
+
+	and $d011       ; clear raster interrupt MSB
+	sta $d011
+	and #$78        ; save vic mode
+	sta .vicmode
+
+	lda $d011       ; save original Yscroll
+	and #$07
+	sta .orgscrl
+
+	lda $0314       ; save the original interrupt vector
+	sta .vector + 1
+	lda $0315
+	sta .vector + 2
+
+	lda #<.vidirq   ; change the interrupt vector
+	sta $0314
+	lda #>.vidirq
+	sta $0315
+
+	lda .raster_border ; set first IRQ for bottom of screen
+	sta $d012
+
+	lda $d01a       ; enable raster interrupts
+	ora #$01
+	sta $d01a
+
+	cli
++++	rts
+
+;--------------------
+; Raster interrupt handler
+.vidirq
+	; We have 19-27 cycles until the raster line advances.
+	; 8 cycles
+	lda $d019       ; triggered by raster position?
+	and #$01
+	beq .stdirq
+
+	; 15 cycles (to .shift_screen)
+	ldx $d012
+	cpx #.raster_top
+	bcc .tos
+	cpx .raster_bot
+	bcc .shift_screen
+.bos                    ; raster >= .raster_bot
+	; Hide the idle-state gap at the bottom of the screen.
+	; 10 cycles
+	ldx .filler
+	lda #$00
+	sta .filler
+
+	; 10 cycles
+	ldy .raster_border
+	dey
+-	cpy $d012
+	bcs -
+
+	stx .filler
+
+	bit .fld
+	bmi +
+	dec .fld
++
+	; Past the text area, so perform top-of-screen handling now.
+.tos                    ; raster < .raster_top
+	lda .orgscrl    ; top of screen--set default scroll
+	ora .vicmode
+	sta $d011
+
+	; Calculate the raster line to interrupt for scrolling update.
+	; The target bad line to defer is reserve*8+48+Yscroll.
+	; We need to interrupt 2 lines before that, in order to:
+	; 1. [t-2] use the remaining time in the interrupted line
+	; 2. [t-1] use some of the next line (#1 is not enough time)
+	; 3. [t-1] set Yscroll to prevent the bad-line condition in t-0
+	lda .reserve
+	asl
+	asl
+	asl
+	adc #.raster_top - 2
+	adc .orgscrl
+	sta .irqline    ; stash it for reference
+
+	tax
+	bit .fld
+	bpl .setirq     ; scrolling in progress
+	; Need a second IRQ in the frame for the clock, but a bit later
+	; in order to avoid colliding with the wait-loop in smoothscroll.
+	inx
+	inx
+	inx
+.setirq
+	stx $d012
+	lda #$01        ; unlatch raster IRQ flag
+	sta $d019
+	lda #$7f
+	sta $dc0d       ; disable CIA#1 IRQ (in case it's been re-enabled)
+
+	lda $dc0d       ; need a kernal interrupt?
+	bne .stdirq
+	lda .fld
+	bne .return     ; once per scroll, make up the skipped IRQ
+.stdirq
+	bit smoothcritical
+	bmi .return
+.vector
+	jmp $ea31
+
+.shift_screen
+	; 6 cycles
+	ldy .fld
+	; Interrupts can get delayed to unexpected times during disk I/O,
+	; so make sure we're really supposed to be scrolling.
+	bmi .reset
+
+	; 13 cycles
+	; Hide the gap we're about to create.
+	lda .filler
+	pha
+	lda #$00
+	sta .filler
+
+	; With a fast CPU (e.g. SuperCPU) we may have to wait for the
+	; raster to reach where it needs to be.
+	; 12 cycles
+	ldx .irqline
+	inx
+-	cpx $d012
+	bne -
+
+	; 2 cycles
+	dex
+
+.next
+	; 14 cycles
+	txa
+	and #$07        ; prevent vic bad-line
+	ora .vicmode
+	sta $d011
+	inx
+
+	; 4 cycles
+	dey
+	bmi +
+
+-	cpx $d012       ; wait for next line
+	beq -
+
+	; 3 cycles
+	bne .next ; always
++
+	; 16 cycles
+	inx             ; set up bad-line condition
+	inx
+	txa
+	and #$07
+	ora .vicmode
+	sta $d011
+
+-	cpx $d012       ; wait to reach the "bad" line
+	bne -
+
+	; 7 cycles
+	pla             ; restore the fill value
+	sta .filler
+
+.reset
+	; set up bottom-of-screen interrupt
+	lda $d011
+	and #$07
+	cmp #$03
+	bcc +
+	lda #$03
+	clc
++	adc .raster_bot
+	tax
+	bne .setirq ; always
+
+.return
+	pla             ; restore Y, X, A
+	tay
+	pla
+	tax
+	pla
+	rti
+} ; zone smoothscroll

--- a/asm/text.asm
+++ b/asm/text.asm
@@ -935,6 +935,9 @@ find_word_in_dictionary
 !ifdef USE_BLINKING_CURSOR {
 update_cursor_timer
 	; calculate when the next cursor update occurs
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_readtime  ; read current time (in jiffys)
 	clc
 	adc #USE_BLINKING_CURSOR
@@ -997,6 +1000,9 @@ init_read_text_timer
 	; sta .read_text_time_jiffy
 update_read_text_timer
 	; prepare time for next routine call (current time + time_jiffy)
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_readtime  ; read current time (in jiffys)
 	clc
 	adc .read_text_time_jiffy + 2
@@ -1012,6 +1018,9 @@ update_read_text_timer
 
 getchar_and_maybe_toggle_darkmode
 	stx .getchar_save_x
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_getchar
 !ifndef NODARKMODE {
  	cmp #133 ; Charcode for F1
@@ -1019,6 +1028,13 @@ getchar_and_maybe_toggle_darkmode
 	jsr toggle_darkmode
 	jmp .did_something
 +	
+}
+!ifdef SMOOTHSCROLL {
+	cmp #137 ; F2
+	bne +
+	jsr toggle_smoothscroll
+	jmp .did_something
++
 }
 !ifdef SCROLLBACK {
 	cmp #135 ; F5
@@ -1084,6 +1100,9 @@ read_char
 !ifdef USE_BLINKING_CURSOR {
 	; check if time for to update the blinking cursor
 	; http://www.6502.org/tutorials/compare_beyond.html#2.2
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_readtime   ; read start time (in jiffys) in a,x,y (low to high)
 	cmp .cursor_jiffy + 2
 	txa
@@ -1137,6 +1156,9 @@ read_char
 	lda .read_text_time
 	ora .read_text_time + 1
 	beq .no_timer
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	jsr kernal_readtime   ; read start time (in jiffys) in a,x,y (low to high)
 	cmp .read_text_jiffy + 2
 	txa

--- a/asm/utilities.asm
+++ b/asm/utilities.asm
@@ -40,14 +40,14 @@ plus4_enable_rom = $ff3e
 
 !macro before_dynmem_read {
 !ifdef TARGET_PLUS4 {
-	sei
+	+disable_interrupts
 	sta plus4_enable_ram
 }
 }
 !macro after_dynmem_read {
 !ifdef TARGET_PLUS4 {
 	sta plus4_enable_rom
-	cli
+	+enable_interrupts
 }
 }
 
@@ -127,11 +127,17 @@ plus4_enable_rom = $ff3e
 
 ; to be expanded to disable NMI IRQs later if needed
 !macro disable_interrupts {
+!ifdef SMOOTHSCROLL {
+	jsr smoothscroll_off
+}
 	sei 
 }
 
 !macro enable_interrupts {
 	cli
+!ifdef SMOOTHSCROLL {
+	jsr smoothscroll_on
+}
 }
 
 
@@ -150,11 +156,11 @@ plus4_enable_rom = $ff3e
 read_next_byte_at_z_pc_sub
 	ldy #0
 !ifdef TARGET_PLUS4 {
-	sei
+	+disable_interrupts
 	sta plus4_enable_ram
 	lda (z_pc_mempointer),y
 	sta plus4_enable_rom
-	cli
+	+enable_interrupts
 } else {
 !ifdef SKIP_BUFFER {
 	+disable_interrupts

--- a/asm/vmem.asm
+++ b/asm/vmem.asm
@@ -576,6 +576,9 @@ hej
 	sta allow_2mhz_in_40_col
 	sta reg_2mhz	;CPU = 1MHz
 }
+!ifdef SMOOTHSCROLL {
+	jsr wait_smoothscroll
+}
 	lda #%10010001;  REU -> c128 with immediate execution
 	sta reu_command
 !ifdef TARGET_C128 {

--- a/make.rb
+++ b/make.rb
@@ -9,11 +9,11 @@ if $is_windows then
     $X64 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\x64sc.exe -autostart-warp" # -autostart-delay-random"
     $X128 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\x128.exe -80 -autostart-delay-random"
     $XPLUS4 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\xplus4.exe -autostart-delay-random"
-	$MEGA65 = "\"C:\\Program Files\\xemu\\xmega65.exe\" -syscon" # -syscon is a workaround for a serious xemu bug
+  $MEGA65 = "\"C:\\Program Files\\xemu\\xmega65.exe\" -syscon" # -syscon is a workaround for a serious xemu bug
     $C1541 = "C:\\ProgramsWoInstall\\WinVICE-3.1-x64\\c1541.exe"
     $EXOMIZER = "C:\\ProgramsWoInstall\\Exomizer-3.1.0\\win32\\exomizer.exe"
     $ACME = "C:\\ProgramsWoInstall\\acme0.97win\\acme\\acme.exe"
-	$commandline_quotemark = "\""
+  $commandline_quotemark = "\""
 else
 	# Paths on Linux
     $X64 = "x64 -autostart-delay-random"
@@ -35,6 +35,7 @@ $GENERALFLAGS = [
 #	'SLOW', # Remove some optimizations for speed. This makes the terp ~100 bytes smaller.
 #	'NODARKMODE', # Disables darkmode support. This makes the terp ~100 bytes smaller.
 #	'NOSCROLLBACK', # Disables scrollback support (MEGA65, C64, C128). This makes the terp ~1 KB smaller.
+#	'NOSMOOTHSCROLL', # Disables smooth-scrolling support.
 #	'REUBOOST', # Enables REU Boost (MEGA65, C64, C128). This makes the terp ~160 bytes larger.
 #	'VICE_TRACE', # Send the last instructions executed to Vice, to aid in debugging
 #	'TRACE', # Save a trace of the last instructions executed, to aid in debugging
@@ -1049,7 +1050,10 @@ def build_interpreter()
 	if $use_history and $use_history > 0
 		optionalsettings += " -DUSE_HISTORY=#{$use_history}"
 	end
-	
+	if $target != 'c64'
+		optionalsettings += " -DNOSMOOTHSCROLL=1"
+	end
+
 	generalflags = $GENERALFLAGS.empty? ? '' : " -D#{$GENERALFLAGS.join('=1 -D')}=1"
 	debugflags = $DEBUGFLAGS.empty? ? '' : " -D#{$DEBUGFLAGS.join('=1 -D')}=1"
 	colourflags = $colour_replacement_clause
@@ -2033,7 +2037,8 @@ def print_usage
 	puts "  -sc/dmsc: Use the specified status line colour. Only valid for Z3 games. See docs for details."
 	puts "  -ic/dmic: Use the specified input colour. Only valid for Z3 and Z4 games. See docs for details."
 	puts "  -dm: Enable the ability to switch to dark mode"
-	puts "  -ss1, -ss2, -ss3, -ss4: Add up to four lines of text to the splash screen."
+        puts "  -smooth: Enable smooth-scrolling support (C64). This makes the terp ~460 bytes larger."
+    puts "  -ss1, -ss2, -ss3, -ss4: Add up to four lines of text to the splash screen."
 	puts "  -sw: Set the splash screen wait time (1-999 s), or 0 to disable splash screen."
 	puts "  -cb: Set cursor blink frequency (1-99, where 1 is fastest)."
 	puts "  -cc/dmcc: Use the specified cursor colour.  Defaults to foreground colour."
@@ -2101,6 +2106,7 @@ $scrollback_ram_pages = nil
 reserve_dir_track = nil
 check_errors = nil
 dark_mode = nil
+smooth_scroll = nil
 scrollback = nil
 reu_boost = nil
 
@@ -2248,6 +2254,12 @@ begin
 				dark_mode = 1
 			else
 				dark_mode = $1.to_i
+			end
+		elsif ARGV[i] =~ /^-smooth(?::([01]))?$/ then
+			if $1 == nil
+				smooth_scroll = 1
+			else
+				smooth_scroll = $1.to_i
 			end
 		elsif ARGV[i] =~ /^-sb(?::(0|1|6|8|10|12))?$/ then
 			if $1 == nil
@@ -2617,6 +2629,10 @@ $is_lurkinghorror = $zcode_version == 3 && $lurkinghorror_releases.has_key?(stor
 if dark_mode == 0
 	$GENERALFLAGS.push('NODARKMODE') unless $GENERALFLAGS.include?('NODARKMODE')
 end	
+
+if smooth_scroll == 1
+	$GENERALFLAGS.push('SMOOTHSCROLL') unless $GENERALFLAGS.include?('SMOOTHSCROLL') or $GENERALFLAGS.include?('NOSMOOTHSCROLL')
+end
 
 if is_beyondzork
 	$interpreter_number = 2 unless $interpreter_number

--- a/make.rb
+++ b/make.rb
@@ -9,11 +9,11 @@ if $is_windows then
     $X64 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\x64sc.exe -autostart-warp" # -autostart-delay-random"
     $X128 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\x128.exe -80 -autostart-delay-random"
     $XPLUS4 = "C:\\ProgramsWoInstall\\GTK3VICE-3.6.1-win64\\bin\\xplus4.exe -autostart-delay-random"
-  $MEGA65 = "\"C:\\Program Files\\xemu\\xmega65.exe\" -syscon" # -syscon is a workaround for a serious xemu bug
+	$MEGA65 = "\"C:\\Program Files\\xemu\\xmega65.exe\" -syscon" # -syscon is a workaround for a serious xemu bug
     $C1541 = "C:\\ProgramsWoInstall\\WinVICE-3.1-x64\\c1541.exe"
     $EXOMIZER = "C:\\ProgramsWoInstall\\Exomizer-3.1.0\\win32\\exomizer.exe"
     $ACME = "C:\\ProgramsWoInstall\\acme0.97win\\acme\\acme.exe"
-  $commandline_quotemark = "\""
+	$commandline_quotemark = "\""
 else
 	# Paths on Linux
     $X64 = "x64 -autostart-delay-random"
@@ -2038,7 +2038,7 @@ def print_usage
 	puts "  -ic/dmic: Use the specified input colour. Only valid for Z3 and Z4 games. See docs for details."
 	puts "  -dm: Enable the ability to switch to dark mode"
         puts "  -smooth: Enable smooth-scrolling support (C64). This makes the terp ~460 bytes larger."
-    puts "  -ss1, -ss2, -ss3, -ss4: Add up to four lines of text to the splash screen."
+        puts "  -ss1, -ss2, -ss3, -ss4: Add up to four lines of text to the splash screen."
 	puts "  -sw: Set the splash screen wait time (1-999 s), or 0 to disable splash screen."
 	puts "  -cb: Set cursor blink frequency (1-99, where 1 is fastest)."
 	puts "  -cc/dmcc: Use the specified cursor colour.  Defaults to foreground colour."


### PR DESCRIPTION
This feature adds smooth-scrolling support for the `c64` target as described in issue #50.  When active, text is scrolled up one pixel (raster line) per frame rather than an entire character (text row) at a time, providing a "smooth" visual experience.  The code for the feature is in the new file `smoothscroll.asm`.

Moving the screen data is performed using the existing scrolling code in `screenkernal.asm`, while the fine-scrolling manipulation is performed in a raster interrupt.  This means that some program processing, including printing to the screen, could occur while scrolling is being performed.  This helps keep an overall smooth effect when multiple lines are being printed and scrolled (such as with a long room description), but it also means that some coordination is necessary to prevent visual glitches when:
* the program wants to scroll again while scrolling is in progress
* the program will disable interrupts
* the program will perform REU access, which pauses the CPU

One mechanism provided to handle this is the `wait_smoothscroll` function, which can be called to wait until any current scrolling activity has completed.  Another is the `smoothscroll_off` and `smoothscroll_on` functions, which can be used to temporarily disable and later re-enable smooth-scrolling.  The latter are used in the macros `disable_interrupts` and `enable_interrupts`, which are now typically used in place of explicit `sei` and `cli` instructions.

The build option `-smooth` can be used to include smoothscrolling support, though it will be disabled (by setting `NOSMOOTHSCROLL`) if the build target is not `c64`.

The user can toggle whether smooth scrolling is active using the `F2` key during the game.  Smooth scrolling is activated at program startup if the support was included.  I haven't added anything to the splash screen yet, as I think it may be better to discuss that as a separate consideration.  (Adding a third independent option increases the complexity, though I do have some ideas and initial code to propose.)

The inclusion of smooth scrolling adds about 460 bytes to the interpreter size.  It might make sense to exclude the "scroll delay" capability when smooth scrolling is included.  While it doesn't interfere, the delay doesn't do much since smooth scrolling is already around 4 times slower than regular scrolling.  It looks like this might save 34 bytes.  (I wasn't certain of the reason for the delay feature, so appreciate your opinions.)

### Testing
Most testing was done using VICE, in PAL and NTSC modes.  A bit of interim testing and some final sanity tests were done on NTSC hardware.
Built some games without `-smooth`, with different feature combinations and for non-C64 targets.
#### Highlights and interesting/useful aspects
##### Hardware Features
* PAL (VICE) and NTSC (VICE/physical)
* REU present/absent (VICE/physical)
* SuperCPU (VICE)
##### Border Zone
* Uses an on-screen clock, checked aginst a stopwatch.
* Initially scrolls a bit of text with a zero-size upper window, then refreshes and sets a 3-line status window.
* Prints text based on time-triggered events without player input.
##### Zork series (1-3 and Minizork)
* Uses a one-line status area.
* Zork 3 had a nonzero value in $3FFF; the others had 0.
##### Beyond Zork
* Uses a large upper window (about half the screen).
##### The Job
* A menu can be accessed which uses an upper window of a different size than in-game.
##### Curses
* Presents a quote box at the beginning which seems to vary in size and content between game runs (though no scrolling is invoked while it is on the screen, and the game appears to be designed for more than 40 columns).
* Help menu, information screens, and gameplay use different upper window sizes.
