### PR TITLE
Smooth-scrolling for C128 in 40-column mode

### DIFF
--- a/asm/disk.asm
+++ b/asm/disk.asm
@@ -858,8 +858,9 @@ list_save_files
 +   ldy #0      ; secondary address 2
 	jsr kernal_setlfs ; call SETLFS
 	jsr kernal_open     ; call OPEN
-	bcs disk_error    ; if carry set, the file could not be opened
-
+	bcc +
+	jmp disk_error    ; if carry set, the file could not be opened
++
 	ldx #2      ; filenumber 2
 	jsr kernal_chkin ; call CHKIN (file 2 now used as input)
 

--- a/asm/ozmoo.asm
+++ b/asm/ozmoo.asm
@@ -769,6 +769,7 @@ use_2mhz_in_80_col !byte 0 ; Initial value should always be 0
 
 use_2mhz_in_80_col_in_game_value = 1 ; This value is used after setup
 
+!ifndef SMOOTHSCROLL {
 ;phase 2 of 2MHz speed-up = change CPU to 2MHz
 ;and set raster IRQ for top-of-screen less 1 raster
 ;and do normal KERNAL routines of IRQ
@@ -809,6 +810,7 @@ c128_border_phase1
 	lsr		; A = 0
 	sta reg_2mhz	;CPU = 1MHz
 	jmp $ff33	;return from IRQ
+}
 
 } else {
 !source "constants.asm"
@@ -984,6 +986,7 @@ game_id		!byte 0,0,0,0
 	sta $d011
 	jmp ++
 +	; 40 columns mode
+!ifndef SMOOTHSCROLL {
 	; use 2MHz only when rasterline is in the border for VIC-II
 	sei 
 	lda #<c128_border_phase2
@@ -995,9 +998,10 @@ game_id		!byte 0,0,0,0
 	sta $d011
 	lda #251 ; low raster bit (1 raster beyond visible screen)
 	sta $d012
+	cli
+}
 ++
 }
-	cli
 
 !ifdef SCROLLBACK {
 	lda scrollback_supported
@@ -1307,9 +1311,6 @@ vmem_cache_count = vmem_cache_size / 256
 stack_start
 
 deletable_screen_init_1
-!ifdef SMOOTHSCROLL {
-	jsr toggle_smoothscroll
-}
 	; start text output from bottom of the screen
 
 !ifndef Z4PLUS {
@@ -1346,6 +1347,9 @@ deletable_screen_init_1
 	jmp erase_window
 
 deletable_screen_init_2
+!ifdef SMOOTHSCROLL {
+	jsr toggle_smoothscroll
+}
 	; clear and unsplit screen, start text output from bottom of the screen (top of screen if z5)
 	ldy #1
 	sty is_buffered_window

--- a/make.rb
+++ b/make.rb
@@ -2035,7 +2035,7 @@ def print_usage
 	puts "  -dm: Enable the ability to switch to dark mode"
 	puts "  -ss1, -ss2, -ss3, -ss4: Add up to four lines of text to the splash screen."
 	puts "  -sw: Set the splash screen wait time (1-999 s), or 0 to disable splash screen."
-	puts "  -smooth: Enable smooth-scrolling support (C64)."
+	puts "  -smooth: Enable smooth-scrolling support (C64, C128)."
 	puts "  -cb: Set cursor blink frequency (1-99, where 1 is fastest)."
 	puts "  -cc/dmcc: Use the specified cursor colour.  Defaults to foreground colour."
 	puts "  -cs: Use the specified cursor shape.  ([b]lock (default), [u]nderscore or [l]ine)"
@@ -2314,7 +2314,7 @@ end
 if smooth_scroll == nil
 	smooth_scroll = 0
 end
-if $target !~ /^(c64)$/ and smooth_scroll == 1
+if $target !~ /^(c64|c128)$/ and smooth_scroll == 1
 	puts "ERROR: Smooth scroll is not available for this platform." 
 	exit 1
 end


### PR DESCRIPTION
This change adds smooth-scrolling support for the C128 in 40-column mode.

When smooth-scrolling is included in the build (using `-smooth`), the "speedup" raster interrupt in `ozmoo.asm` will not be included since the one in `smoothscroll.asm` is used instead.  The speedup functionality has been separately integrated into that handler.  (When `-smooth` is not used, the original raster interrupt handler in `ozmoo.asm` is used and `smoothscroll.asm` is not included in the build.)

The initial activation of smooth-scrolling is moved into `deletable_screen_init_2`, as doing it earlier was interfering with REU detection (perhaps due to the CPU speedup).

A branch in `disk.asm` became too far in C128 mode with smooth-scrolling included, so this is worked around using `jmp`.

In memory.asm:
The `read_word_from_far_dynmem` and/or `write_word_to_far_dynmem` routines are called _very_ frequently, and waiting for scrolling to complete each time disrupted the overall experience.  Instead of using the usual macros to manage interrupts, these now use `sei` and `cli` again and call a new routine `wait_smoothscroll_min` to avoid interfering with scrolling.

The original use of the `disable_interrupts` and `enable_interrupts` macros with the inclusion of smooth-scrolling caused the `copy_page_c128_src` code section to become too large for the area into which it is copied.  I was able to save a couple of bytes by a slight refactoring of code at the top of this section.  I'm not sure that it is strictly needed now (since the changes described in the previous paragraph), but if you feel that the original code is more readable then I can try reverting this change.


There is an aspect of possible (future?) concern which I wanted to point out for awareness.  Some memory access routines (in `memory.asm`) are copied into an always-available memory area at $0380.  With smooth-scrolling included these are now calling other routines in memory (~$1400) which is _not_ available in every possible C128 bank configuration.  However it appears that Ozmoo always banks RAM block 0 (based on the `set_memory_*` macros in `utilities.asm`), which means that these routines are always available in Ozmoo.

### Testing

In general I did testing similar to that described in PR #54 but mainly focused on the C128 in 40-column mode.  I also did some sanity/regression testing in 80-column mode and C64.  I added Vacation Gone Awry (playing with the statusline modes) and Trinity to the mix.

Beyond Zork works, but some of the introductory text appears to be printed in the background color.  The behavior is the same with a pre-smoothscroll Ozmoo build, so this is just an FYI observation.

Most testing was done using VICE (PAL and NTSC), with a final round on NTSC hardware.  80-column mode on the physical machine appeared to have some issues with missing characters and garbled text in multiple games, but that was also the case with games built using a pre-smoothscroll Ozmoo tree.  So I'm tentatively assuming that my machines may be developing some age-related issues.  (I tried two systems with similar results.  The SD2IEC file browser worked fine, and the Ozmoo title screen looked fine every time.  I don't think I will have time to diagnose the hardware much further in the near term.)
